### PR TITLE
Rename default branch to `main`

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -41,6 +41,6 @@ manifest:
     - name: 6tron-manifest
       remote: catie-6tron
       repo-path: zephyr_6tron-manifest
-      revision: main
+      revision: v3.5.0+202402
       path: 6tron/6tron-manifest
       import: true


### PR DESCRIPTION
Next rename will be with first release, but currently, `master` branch of 6TRON module doesn't exist anymore.