### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/linux/devcontainer.json
+++ b/.devcontainer/linux/devcontainer.json
@@ -1,0 +1,17 @@
+{
+	"name": "6TRON Zephyr",
+	"image": "ghcr.io/catie-aq/zephyr_docker:v4.1.0-202505-dev",
+
+	"features": {
+		"ghcr.io/devcontainers-extra/features/pre-commit:2": {}
+	},
+
+	"runArgs": ["--privileged"],
+
+	"mounts": [
+		"source=/dev/bus/usb,target=/dev/bus/usb,type=bind"
+	],
+
+	"workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspace,type=bind",
+	"workspaceFolder": "/workspace"
+}

--- a/.devcontainer/windows/devcontainer.json
+++ b/.devcontainer/windows/devcontainer.json
@@ -1,0 +1,13 @@
+{
+	"name": "6TRON Zephyr",
+	"image": "ghcr.io/catie-aq/zephyr_docker:v4.1.0-202505-dev",
+
+	"features": {
+		"ghcr.io/devcontainers-extra/features/pre-commit:2": {}
+	},
+
+	"runArgs": ["--privileged"],
+
+	"workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspace,type=bind",
+	"workspaceFolder": "/workspace"
+}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,50 @@
 # Zephyr 6TRON workspace
 
 ## Usage
+
+> [!NOTE]
+> You can use Dev Containers to develop in a consistent environment. This ensures that all dependencies and tools are correctly set up.
+
+### With DevContainer
+
+- Clone the repository
+
+```bash
+mkdir 6tron-workspace
+cd 6tron-workspace
+git clone https://github.com/catie-aq/6tron_zephyr-workspace 6tron-project
+```
+
+- Open the workspace in Visual Studio Code
+
+```bash
+code 6tron-project
+```
+
+- Open the workspace in the DevContainer: `Ctrl+Shift+P` > `Reopen in Container`
+- Choose between the Linux or Windows devcontainer depending on your operating system.
 - Initialize the Zephyr workspace
+
+```bash
+west init -l 6tron-project
+```
+
+- Update workspace
+
+```bash
+west update
+```
+
+### Without DevContainer
+
+- Initialize the Zephyr workspace
+
 ```bash
 west init -m https://github.com/catie-aq/6tron_zephyr-workspace 6tron-workspace
 ```
 
 - Update workspace
+
 ```bash
-cd 6tron-workspace
 west update
 ```


### PR DESCRIPTION
This pull request adds support for Dev Containers to the Zephyr 6TRON workspace, making it easier to set up a consistent development environment across Linux and Windows. The documentation has been updated with instructions for using Dev Containers in Visual Studio Code.

Dev Container support:

* Added `.devcontainer/linux/devcontainer.json` and `.devcontainer/windows/devcontainer.json` to provide pre-configured development environments for Linux and Windows, including the appropriate Docker image, pre-commit hooks, privileged container settings, and workspace mounting. [[1]](diffhunk://#diff-3d96399d6b6e9c710900b8ebde0908d369d239ece0f06829202a8fea142bb264R1-R17) [[2]](diffhunk://#diff-0bd9b33fb862bce9397876365bbf715019deb04826e1460e093950837da5b23eR1-R13)

Documentation updates:

* Updated `README.md` with detailed instructions for using Dev Containers.