### PR TITLE
Update to Zephyr OS 4.2.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v4.1.0
+      revision: v4.2.0
       import:
         name-blocklist:
           - hal_altera
@@ -41,6 +41,6 @@ manifest:
     - name: 6tron_manifest
       remote: catie-6tron
       repo-path: zephyr_6tron-manifest
-      revision: v4.1.0+202505
+      revision: v4.2.0+202508
       path: 6tron/6tron_manifest
       import: true


### PR DESCRIPTION
This pull request updates the Zephyr RTOS version to 4.2.0.

Dependency version updates:

* Upgraded the `zephyr` project revision from `v4.1.0` to `v4.2.0` in `west.yml`, aligning with the latest Zephyr RTOS release.
* Updated the `6tron_manifest` project revision from `v4.1.0+202505` to `v4.2.0+202508` in `west.yml`, ensuring compatibility with the updated Zephyr version.