### PR TITLE
Integrate stse-module to west.yaml

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -44,3 +44,9 @@ manifest:
       revision: v4.2.0+202508
       path: 6tron/6tron_manifest
       import: true
+    - name: stselib-module
+      remote: catie-6tron
+      repo-path: zephyr_stselib-module
+      revision: v1.1.1
+      path: 6tron/stselib_module
+      submodules: true


### PR DESCRIPTION
This pull request adds a new module dependency to the project manifest. The most important change is the inclusion of the `stselib-module` from the `catie-6tron` remote, specifying its repository path, revision, and enabling submodules.

Dependency management:

* Added the `stselib-module` as a new dependency in the `west.yml` manifest, specifying its remote (`catie-6tron`), repository path (`zephyr_stselib-module`), revision (`v1.1.1`), local path (`6tron/stselib_module`), and enabling submodules.