### PR TITLE
Update to Zephyr OS 4.3.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -14,7 +14,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: v4.2.0
+      revision: v4.3.0
       import:
         name-blocklist:
           - hal_altera
@@ -41,6 +41,6 @@ manifest:
     - name: 6tron_manifest
       remote: catie-6tron
       repo-path: zephyr_6tron-manifest
-      revision: v4.2.0+202508
+      revision: v4.3.0+202511
       path: 6tron/6tron_manifest
       import: true


### PR DESCRIPTION
This pull request updates the Zephyr RTOS and 6tron manifest versions in the `west.yml` file to their latest releases.

* Updated the Zephyr RTOS project revision from `v4.2.0` to `v4.3.0` in `west.yml` to use the latest stable release.
* Updated the 6tron manifest project revision from `v4.2.0+202508` to `v4.3.0+202511` in `west.yml` for compatibility with the new Zephyr version.